### PR TITLE
Fix issue with lab process_services bailing out

### DIFF
--- a/src/dp/lab.py
+++ b/src/dp/lab.py
@@ -215,8 +215,7 @@ def _process_services(
         comprehensive_search = operation not in [OperationType.kill]
         services = _find_services(ns, verbose, comprehensive=comprehensive_search)
         if not services:
-            print_err(f"No services found in {ns} namespace")
-            raise typer.Exit(code=1)
+            logger.info(f"No services found in {ns} namespace")
 
         for service in services:
             try:
@@ -389,7 +388,8 @@ def _find_services(
             release["created"] = history[0]["updated"]
 
             values = _get_helm_release_values(release_name, namespace)
-            release["suspended"] = values["global"]["suspend"]
+            print(values)
+            release["suspended"] = values.get("global", {}).get("suspend", False)
 
     services: list[Service] = [Service(**data) for data in helm_releases]
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1,4 +1,5 @@
 import io
+import logging
 
 import pytest
 import typer
@@ -104,18 +105,13 @@ def test_kill_service_dryrun(mocker):
     )
 
 
-def test_kill_services_no_services(mocker):
+def test_kill_services_no_services(mocker, caplog):
     mocker.patch("dp.lab._find_services", return_value=[])
     mocker.patch("dp.lab._validate_env")
 
-    with mocker.patch("sys.stderr", new=io.StringIO()) as mock_stderr:
-        with pytest.raises(typer.Exit) as exc_info:
-            lab.kill_services(
-                env=Env.dev, namespace="some-ns", dryrun=False, verbose=True
-            )
-
-        assert "No services found in some-ns namespace" in mock_stderr.getvalue()
-        assert exc_info.value.exit_code == 1
+    with caplog.at_level(logging.INFO):
+        lab.kill_services(env=Env.dev, namespace="some-ns", dryrun=False, verbose=True)
+        assert "No services found in some-ns namespace" in caplog.text
 
 
 def test_kill_services_with_services(mocker):

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1,9 +1,6 @@
 import io
 import logging
 
-import pytest
-import typer
-
 from dp import lab
 from dp.lab import Env, Service
 from dp.utils import RunResult, strip_ansi


### PR DESCRIPTION
This fixes an issue with prune, kill or suspend exiting for all namespaces if we encounter a user namespace with no services running.