### PR TITLE
Refresh versions

### DIFF
--- a/src/dp/annotations.py
+++ b/src/dp/annotations.py
@@ -1,10 +1,14 @@
+import os
 from collections.abc import Callable
+from datetime import datetime, timedelta
 from functools import wraps
 from typing import Any
 
+import typer
 from rich import print
 
-from .utils import red
+from . import config
+from .utils import get_current_version, get_latest_pypi_version, print_err, red, run
 
 
 def dryrunnable(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -24,3 +28,79 @@ def dryrunnable(f: Callable[..., Any]) -> Callable[..., Any]:
         return f(*args, **kwargs)
 
     return wrapper
+
+
+def ensure_helm_repos_updated(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Annotation to ensure Helm repo is updated if necessary before running a helm command that relies on helm repos."""
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        config_section = "helm"
+        config_key = "repos_last_updated"
+        last_updated = _get_config_timestamp(config_section, config_key)
+
+        if datetime.now() - last_updated > timedelta(hours=2):
+            res = run("helm repo update")
+            if res.returncode != 0:
+                print_err(f"Failed to update Helm repos: {res.stderr}")
+                raise typer.Exit(code=1)
+
+            _update_config_timestamp(config_section, config_key)
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def check_version(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Annotation to check for newer versions from PyPI.
+
+    This annotation checks for newer versions from PyPI and prints a message if a newer version is available.
+    The check is performed once every 24 hours. You can disable this check by setting the environment
+    variable DAPLA_CLI_NO_VERSION_CHECK to any value.
+    """
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if os.getenv("DAPLA_CLI_NO_VERSION_CHECK"):
+            return f(*args, **kwargs)
+
+        config_section = "general"
+        config_key = "last_checked_version"
+        last_updated = _get_config_timestamp(config_section, config_key)
+
+        if datetime.now() - last_updated > timedelta(hours=24):
+            current_version = get_current_version()
+            latest_pypi_version = get_latest_pypi_version()
+
+            if current_version and latest_pypi_version:
+                if current_version >= latest_pypi_version:
+                    print(
+                        f"A new version is available: {latest_pypi_version} (Installed: {current_version})"
+                    )
+
+            _update_config_timestamp(config_section, config_key)
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def _get_config_timestamp(
+    section: str, key: str, default: str = "1970-01-01T00:00:00"
+) -> datetime:
+    """Get a timestamp from the config."""
+    last_updated_str = config.get(section=section, key=key, namespace=None)
+    return (
+        datetime.fromisoformat(last_updated_str)
+        if last_updated_str
+        else datetime.fromisoformat(default)
+    )
+
+
+def _update_config_timestamp(section: str, key: str) -> None:
+    """Update the config with the current timestamp."""
+    config.put(
+        section=section,
+        key=key,
+        value=datetime.now().isoformat(),
+        namespace=None,
+    )

--- a/src/dp/lab.py
+++ b/src/dp/lab.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import typer
 from pydantic import BaseModel
@@ -400,7 +400,7 @@ def _find_service(
     """
     for service in _find_services(namespace, verbose, comprehensive):
         if service.name == service_name:
-            return service
+            return cast(Service, service)
 
     return None
 

--- a/src/dp/main.py
+++ b/src/dp/main.py
@@ -1,10 +1,11 @@
-import importlib.metadata
 import logging
 from typing import Annotated
 
 import typer
 
 from . import auth, lab
+from .annotations import check_version
+from .utils import get_current_version
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -18,15 +19,13 @@ app.add_typer(lab.app, name="lab", help="Interact with Dapla Lab services")
 def version_callback(value: bool) -> None:
     """Print the version."""
     if value:
-        try:
-            app_version = importlib.metadata.version("dapla-cli")
-        except importlib.metadata.PackageNotFoundError:
-            app_version = "dev"
-        print(f"Dapla CLI {app_version}")
+        version = get_current_version() or "dev"
+        print(f"Dapla CLI {version}")
         raise typer.Exit()
 
 
 @app.callback()
+@check_version
 def main(
     version: Annotated[
         bool | None, typer.Option("--version", callback=version_callback)

--- a/src/dp/utils.py
+++ b/src/dp/utils.py
@@ -1,9 +1,12 @@
+import importlib.metadata
 import re
 import subprocess
 from datetime import datetime, timezone
 from typing import Any
 
+import requests
 import typer
+from packaging.version import Version
 from pydantic import BaseModel
 from rich import print
 from rich.console import Console
@@ -94,3 +97,29 @@ def assert_successful_command(cmd: str, err_msg: str, success_msg: str | None) -
         raise typer.Exit(code=res.returncode)
     if success_msg:
         print(f"✔️ {success_msg}")
+
+
+def get_current_version() -> Version | None:
+    """Return the app version."""
+    try:
+        return Version(importlib.metadata.version("dapla-cli"))
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def get_latest_pypi_version() -> Version | None:
+    """Fetches the latest version of a package from PyPI.
+
+    Returns:
+        str: The latest version of the package, or None if there is an error.
+    """
+    url = "https://pypi.org/pypi/dapla-cli/json"
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+
+        # Parse the response as JSON and return the latest version
+        data = response.json()
+        return Version(data["info"]["version"])
+    except Exception:
+        return None


### PR DESCRIPTION
Add annotations for checking for newer versions of Dapla CLI (every 24 hours) and keeping Helm repos updated every 2 hours.