### PR TITLE
Prevent newlines being inserted in the token

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,22 @@ show_column_numbers = true
 show_error_context = true
 ignore_missing_imports = true
 
+# Disable specific error codes in the 'tests' package
+# Also don't require type annotations
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disable_error_code = [
+    "var-annotated",
+    "has-type",
+    "no-any-return",
+    "no-untyped-def",
+]
+
 [tool.ruff]
-force-exclude = true  # Apply excludes to pre-commit
+force-exclude = true # Apply excludes to pre-commit
 show-fixes = true
 src = ["src", "tests"]
-target-version = "py310"  # Minimum Python version supported
+target-version = "py310" # Minimum Python version supported
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 extend-exclude = [
     "__pycache__",
@@ -89,16 +100,16 @@ extend-exclude = [
 # Ruff rules may be customized as desired: https://docs.astral.sh/ruff/rules/
 [tool.ruff.lint]
 select = [
-    "A",    # prevent using keywords that clobber python builtins
-    "ANN",  # check type annotations
-    "B",    # bugbear: security warnings
-    "D",    # documentation
-    "E",    # pycodestyle
-    "F",    # pyflakes
-    "ISC",  # implicit string concatenation
-    "I",    # sort imports
-    "UP",   # alert you when better syntax is available in your python version
-    "RUF",  # the ruff developer's own rules
+    "A",   # prevent using keywords that clobber python builtins
+    "ANN", # check type annotations
+    "B",   # bugbear: security warnings
+    "D",   # documentation
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "ISC", # implicit string concatenation
+    "I",   # sort imports
+    "UP",  # alert you when better syntax is available in your python version
+    "RUF", # the ruff developer's own rules
 ]
 ignore = [
     "ANN101", # Supress missing-type-self.
@@ -117,26 +128,31 @@ force-single-line = false
 max-complexity = 15
 
 [tool.ruff.lint.pydocstyle]
-convention = "google"  # You can also use "numpy".
+convention = "google" # You can also use "numpy".
 
 [tool.ruff.lint.pep8-naming]
-classmethod-decorators = ["classmethod", "validator", "root_validator", "pydantic.validator"]
+classmethod-decorators = [
+    "classmethod",
+    "validator",
+    "root_validator",
+    "pydantic.validator",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
 "**/tests/*" = [
-    "ANN001",  # type annotations don't add value for test functions
-    "ANN002",  # type annotations don't add value for test functions
-    "ANN003",  # type annotations don't add value for test functions
-    "ANN201",  # type annotations don't add value for test functions
-    "ANN204",  # type annotations don't add value for test functions
-    "ANN205",  # type annotations don't add value for test functions
-    "ANN206",  # type annotations don't add value for test functions
-    "D100",    # docstrings are overkill for test functions
+    "ANN001", # type annotations don't add value for test functions
+    "ANN002", # type annotations don't add value for test functions
+    "ANN003", # type annotations don't add value for test functions
+    "ANN201", # type annotations don't add value for test functions
+    "ANN204", # type annotations don't add value for test functions
+    "ANN205", # type annotations don't add value for test functions
+    "ANN206", # type annotations don't add value for test functions
+    "D100",   # docstrings are overkill for test functions
     "D101",
     "D102",
     "D103",
-    "S101",    # asserts are encouraged in pytest
+    "S101",   # asserts are encouraged in pytest
 ]
 
 [build-system]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -48,7 +48,9 @@ def test_show_access_token_prints_token(mocker, capsys):
     mocker.patch("dp.auth.local_access_token", return_value=TEST_TOKEN)
     auth.show_access_token(env=Env.prod)
     auth.local_access_token.assert_called_once_with(Env.prod, ensure_valid=True)
-    assert "\n" not in capsys.readouterr().out.strip()
+    output = capsys.readouterr().out.strip()
+    assert "\n" not in output
+    assert TEST_TOKEN in output
 
 
 def test_show_access_token_decoded(mocker):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,13 +6,15 @@ import typer
 from dp import auth
 from dp.auth import Env
 
+TEST_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
 
 def test_login_successful(mocker):
     mocker.patch(
         "dp.auth._init_device_flow",
         return_value={"device_code": "device_code", "code_verifier": "code_verifier"},
     )
-    mocker.patch("dp.auth._poll_for_token", return_value="access_token")
+    mocker.patch("dp.auth._poll_for_token", return_value=TEST_TOKEN)
     auth.login(env=Env.prod)
     auth._init_device_flow.assert_called_once_with(Env.prod)
     auth._poll_for_token.assert_called_once_with(
@@ -42,28 +44,29 @@ def test_logout_already_logged_out(mocker):
     auth.config.get.assert_called_once_with("auth", "refresh_token", "prod")
 
 
-def test_show_access_token_prints_token(mocker):
-    mocker.patch("dp.auth.local_access_token", return_value="access_token")
+def test_show_access_token_prints_token(mocker, capsys):
+    mocker.patch("dp.auth.local_access_token", return_value=TEST_TOKEN)
     auth.show_access_token(env=Env.prod)
     auth.local_access_token.assert_called_once_with(Env.prod, ensure_valid=True)
+    assert "\n" not in capsys.readouterr().out.strip()
 
 
 def test_show_access_token_decoded(mocker):
-    mocker.patch("dp.auth.local_access_token", return_value="access_token")
+    mocker.patch("dp.auth.local_access_token", return_value=TEST_TOKEN)
     mocker.patch("dp.auth.jwt.decode", return_value={"decoded": "token"})
     auth.show_access_token(env=Env.prod, decoded=True)
     auth.local_access_token.assert_called_once_with(Env.prod, ensure_valid=True)
     auth.jwt.decode.assert_called_once_with(
-        "access_token", options={"verify_signature": False}
+        TEST_TOKEN, options={"verify_signature": False}
     )
 
 
 def test_show_access_token_to_clipboard(mocker):
-    mocker.patch("dp.auth.local_access_token", return_value="access_token")
+    mocker.patch("dp.auth.local_access_token", return_value=TEST_TOKEN)
     mocker.patch("dp.auth.pyperclip.copy")
     auth.show_access_token(env=Env.prod, to_clipboard=True)
     auth.local_access_token.assert_called_once_with(Env.prod, ensure_valid=True)
-    auth.pyperclip.copy.assert_called_once_with("access_token")
+    auth.pyperclip.copy.assert_called_once_with(TEST_TOKEN)
 
 
 def test_local_access_token_not_found(mocker):
@@ -73,7 +76,7 @@ def test_local_access_token_not_found(mocker):
 
 
 def test_local_access_token_refresh_needed(mocker):
-    mocker.patch("dp.auth.config.get", return_value="access_token")
+    mocker.patch("dp.auth.config.get", return_value=TEST_TOKEN)
     mocker.patch("dp.auth.jwt.decode", return_value={"exp": time.time() - 100})
     mocker.patch("dp.auth._refresh_token", return_value="new_access_token")
     token = auth.local_access_token(env=Env.prod)


### PR DESCRIPTION
The `print()` function from `rich` was inserting newlines instead of allowing the terminal to handle wrapping. This causes the token to be invalid. Fix this by using the stdlib print function.

- **Test illustrating that new lines are included in token printed to terminal**
- **Prevent newlines being inserted in token**
